### PR TITLE
Remove Node.js 8, add Node.js 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Set default values for build arguments
 ARG DOCKERFILE_VERSION=1.2.1
-ARG NODE_VERSION=12.18.3-alpine3.12
+ARG NODE_VERSION=14.15.0-alpine3.12
 
 FROM node:$NODE_VERSION AS production
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 import uk.gov.defra.ImageMap
 
 ImageMap[] imageMaps = [
-  [version: '8.17.0', tag: '8.17.0-alpine', latest: false],
-  [version: '12.18.3', tag: '12.18.3-alpine3.12', latest: true],
+  [version: '12.18.3', tag: '12.18.3-alpine3.12', latest: false],
+  [version: '14.15.0', tag: '14.15.0-alpine3.12', latest: true]
 ]
 
 buildParentImage imageName: 'node',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PDEV-74

Add Node.js 14 parent image to allow early adopters to use node 14.

Remove Node.js 8 as no longer supported