### PR TITLE
Update Docker argument name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Set default values for build arguments
-ARG DOCKERFILE_VERSION=1.2.1
-ARG NODE_VERSION=14.15.0-alpine3.12
+ARG DOCKERFILE_VERSION=1.2.2
+ARG BASE_VERSION=14.15.0-alpine3.12
 
-FROM node:$NODE_VERSION AS production
+FROM node:$BASE_VERSION AS production
 
-ARG NODE_VERSION
+ARG BASE_VERSION
 ARG DOCKERFILE_VERSION
 
 ENV NODE_ENV production
@@ -29,7 +29,7 @@ USER node
 WORKDIR /home/node
 
 # Label images to aid searching
-LABEL uk.gov.defra.node.node-version=$NODE_VERSION \
+LABEL uk.gov.defra.node.node-version=$BASE_VERSION \
       uk.gov.defra.node.version=$DOCKERFILE_VERSION \
       uk.gov.defra.node.repository=defradigital/node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Set default values for build arguments
-ARG DOCKERFILE_VERSION=1.2.2
+ARG DEFRA_VERSION=1.2.2
 ARG BASE_VERSION=14.15.0-alpine3.12
 
 FROM node:$BASE_VERSION AS production
 
 ARG BASE_VERSION
-ARG DOCKERFILE_VERSION
+ARG DEFRA_VERSION
 
 ENV NODE_ENV production
 
@@ -30,7 +30,7 @@ WORKDIR /home/node
 
 # Label images to aid searching
 LABEL uk.gov.defra.node.node-version=$BASE_VERSION \
-      uk.gov.defra.node.version=$DOCKERFILE_VERSION \
+      uk.gov.defra.node.version=$DEFRA_VERSION \
       uk.gov.defra.node.repository=defradigital/node
 
 FROM production AS development

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,4 @@ ImageMap[] imageMaps = [
 
 buildParentImage imageName: 'node',
   imageMaps: imageMaps,
-  version: '1.2.1'
+  version: '1.2.2'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-docker-jenkins@v-1') _
+@Library('defra-docker-jenkins@v-2') _
 
 import uk.gov.defra.ImageMap
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker build --no-cache --target <target> .
 ```
 (where <target> is either `development` or `production`).
 
-This will build an image using the default `NODE_VERSION` as set in the [Dockerfile](Dockerfile).
+This will build an image using the default `BASE_VERSION` as set in the [Dockerfile](Dockerfile).
 
 ## Internal CA certificates
 

--- a/examples/Dockerfile.service
+++ b/examples/Dockerfile.service
@@ -1,7 +1,7 @@
 # This assumes that the parent image has been built locally using production and development build configuration as defra-node 
 # and defra-node-development tagged with a version.
 
-ARG BASE_VERSION=1.0.0
+ARG BASE_VERSION=1.2.1-node12.18.3
 FROM defra-node:$BASE_VERSION AS base
 
 # Copy our package files so that our package install will do a clean install. This installs the exact versions of the packages

--- a/examples/Dockerfile.web
+++ b/examples/Dockerfile.web
@@ -1,7 +1,7 @@
 # This assumes that the parent image has been built locally using production and development build configuration as defra-node 
 # and defra-node-development tagged with a version.
 
-ARG BASE_VERSION=1.0.0
+ARG BASE_VERSION=1.2.1-node12.18.3
 FROM defra-node:$BASE_VERSION AS base
 
 # Set the port that is going to be exposed later on in the Dockerfile as well.


### PR DESCRIPTION
The defra-docker-jenkins library uses a language agnostic version argument
`BASE_VERSION` when building an image. `VERSION` has been replaced with `DEFRA_VERSION`.

`NODE_VERSION` and `DOCKERFILE_VERSION` in this repo should be changed to reflect the new names in v2 of the library.