### PR TITLE
update policy file and exclusions

### DIFF
--- a/POLICY_CONFIGURATION.md
+++ b/POLICY_CONFIGURATION.md
@@ -6,4 +6,5 @@ The following issues have been added to the policies exclusion list
 
 | CVE Report    |Type      | Component | Reason       | Date |
 | ------------- | -------  |----------| ------------- | -----------------  |
-| [CVE-2021-27290](https://github.com/advisories/GHSA-vx3p-948g-6vhq) | NPM | [ssri](https://github.com/zkat/ssri) | binary only used by npm installation for npm command line activities, i.e. npm install, and is not used by running applications | 14/04/2021 |
+| [CVE-2021-27290 (github)](https://github.com/advisories/GHSA-vx3p-948g-6vhq) | NPM | [ssri](https://github.com/zkat/ssri) | binary only used by npm installation for npm command line activities, i.e. npm install, and is not used by running applications | 14/04/2021 |
+| [CVE-2021-27290 (NIST)](https://nvd.nist.gov/vuln/detail/CVE-2021-27290) | NPM | [ssri](https://github.com/zkat/ssri) | same issue as above detected as different reports | 14/04/2021 |

--- a/anchore-policy.json
+++ b/anchore-policy.json
@@ -21,7 +21,8 @@
       "name": "NPM binaries Whitelist",
       "version": "1_0",
       "items": [
-        { "id": "item1", "gate": "vulnerabilities", "trigger": "package", "trigger_id": "GHSA-vx3p-948g-6vhq+ssri" }
+        { "id": "item1", "gate": "vulnerabilities", "trigger": "package", "trigger_id": "GHSA-vx3p-948g-6vhq+ssri" },
+        { "id": "item2", "gate": "vulnerabilities", "trigger": "package", "trigger_id": "CVE-2021-27290+ssri" }
       ]
     }
   ],


### PR DESCRIPTION
The SSRI exclusion that has already been documented has been detected as a separate report - one from github and one from NIST.

This PR adds the duplicate [CVE-2021-27290](https://nvd.nist.gov/vuln/detail/CVE-2021-27290) report to the exclusions.
No update to the Defra parent image is required.