### PR TITLE
Add non-exploitable npm binary to exclusion list

### DIFF
--- a/POLICY_CONFIGURATION.md
+++ b/POLICY_CONFIGURATION.md
@@ -6,3 +6,4 @@ The following issues have been added to the policies exclusion list
 
 | CVE Report    |Type      | Component | Reason       | Date |
 | ------------- | -------  |----------| ------------- | -----------------  |
+|[CVE-2021-3807](https://github.com/advisories/GHSA-93q8-gq69-wqmw)| NPM | [ansi-regex](https://github.com/chalk/ansi-regex) | Binary only used by `npm` command line and is not exploitable in a production image | 28/09/2021 |

--- a/anchore-policy.json
+++ b/anchore-policy.json
@@ -20,7 +20,9 @@
       "id": "whitelist1",
       "name": "NPM binaries Whitelist",
       "version": "1_0",
-      "items": []
+      "items": [
+        { "id": "item1", "gate": "vulnerabilities", "trigger": "package", "trigger_id": "GHSA-93q8-gq69-wqmw+ansi-regex" }
+      ]
     }
   ],
   "policies": [


### PR DESCRIPTION
ansi-regex is only used by the npm command line, and is not exploitable
in the running image