### PR TITLE
bump 16.13.2 to 16.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Set default values for build arguments
 ARG DEFRA_VERSION=1.2.15
-ARG BASE_VERSION=16.13.2-alpine3.15
+ARG BASE_VERSION=16.14.0-alpine3.15
 
 FROM node:$BASE_VERSION AS production
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The following table lists the versions of node available, and the parent Node.js
 | ------------- | -----------------  |
 | 12.22.10       | 12.22.10-alpine3.15 |
 | 14.19.0       | 14.19.0-alpine3.15 |
-| 16.13.2       | 16.13.2-alpine3.15 |
+| 16.14.0       | 16.14.0-alpine3.15 |
 
 Two parent images are created for each version:
 
@@ -65,7 +65,7 @@ A simple convenience script [bump](./bump) is provided to substitute version in 
 
 The 'from' and 'to' values to substitute are separated by a colon, and multiple arguments must be separated by a space.
 
-i.e. `./bump 16.13.0:16.13.2 14.18.1:14.19.0` will replace all instances of `16.13.0` with `16.13.2` and all instances of `14.18.1` with `14.19.0`.
+i.e. `./bump 16.13.0:16.14.0 14.18.1:14.19.0` will replace all instances of `16.13.0` with `16.14.0` and all instances of `14.18.1` with `14.19.0`.
 
 ## Licence
 

--- a/image-matrix.json
+++ b/image-matrix.json
@@ -1,5 +1,5 @@
  [
     {"runtimeVersion": "12.22.10", "tags": ["latest-12"]},
     {"runtimeVersion": "14.19.0", "tags": ["latest-14"]},
-    {"runtimeVersion": "16.13.2", "tags": ["latest", "latest-16"]}
+    {"runtimeVersion": "16.14.0", "tags": ["latest", "latest-16"]}
 ]


### PR DESCRIPTION
# Description

Small update as patch of version 16 only -  released a week after the 12 and 14 patches

# Checklist:

- [x] I have ensured the Defra version in the **JOB.env** file matches that in the **Dockerfile**
- [x] I have ensured the Node.js versions in the **image-matrix.json** match the **Dockerfile** and the table in the **README.md**
- [x] I have added newly ignored vulnerabilities to the **POLICY_CONFIGURATION.md**
- [x] I have checked if previously identified vulnerabilities have been patched, and can be removed from the **.grype.yaml** and **POLICY_CONFIGURATION.md** files

